### PR TITLE
Feature/scanrefactor

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -17,7 +17,7 @@ func TestParse_files(t *testing.T) {
 	}
 
 	mode := DeclarationErrors
-	mode = Trace
+	mode = Trace | ParseComments
 	for _, name := range inputs {
 		// These are fucked things in Sass like lists
 		if strings.Contains(name, "15_") {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -210,10 +210,6 @@ func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
 	ch := s.ch
 scanAgain:
 	switch {
-	case ch == '$':
-		s.next()
-		lit = s.scanText(0, false)
-		tok = token.VAR
 	case ch == '&':
 		fallthrough
 	case ch == '[':
@@ -236,16 +232,20 @@ scanAgain:
 		}
 	}
 
-	// move forward
-	s.next()
 	if tok != token.ILLEGAL {
 		return
 	}
+
+	// move forward
+	s.next()
 
 	switch ch {
 	case -1:
 		tok = token.EOF
 		// Look for quoted strings
+	case '$':
+		lit = s.scanText(0, false)
+		tok = token.VAR
 	case '#':
 		// # can be one of three things
 		// color:    #fff[000]
@@ -377,7 +377,7 @@ func (s *Scanner) scanDelim(offs int) (pos token.Pos, tok token.Token, lit strin
 	case eof:
 		return pos, token.EOF, ""
 	case '{':
-		return pos, token.SELECTOR, string(s.src[offs:s.offset])
+		return pos, token.SELECTOR, string(bytes.TrimSpace(s.src[offs:s.offset]))
 	}
 
 	sel := s.src[offs:s.offset]

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -191,9 +191,9 @@ func (s *Scanner) skipWhitespace() {
 // math 1 + 3 or (1 + 3)
 // New strategy, scan until something important is encountered
 func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
-	defer func() {
-		// fmt.Printf("scan tok: %s lit: %s\n", tok, lit)
-	}()
+	// defer func() {
+	// 	fmt.Printf("scan tok: %s lit: %s\n", tok, lit)
+	// }()
 	// Check the queue, which may contain tokens that were fetched
 	// in a previous scan while determing ambiguious tokens.
 	select {
@@ -263,6 +263,12 @@ scanAgain:
 			// s.rhs = true
 			tok = token.COLON
 		}
+	case '-':
+		if isLetter(s.ch) {
+			pos, tok, lit = s.scanDelim(offs)
+		} else {
+			tok = token.SUB
+		}
 	case '\'':
 		lit = s.scanText('\'', true)
 		tok = token.QSSTRING
@@ -331,8 +337,6 @@ scanAgain:
 		tok = token.REM
 	case '+':
 		tok = token.ADD
-	case '-':
-		tok = token.SUB
 	case '*':
 		tok = token.MUL
 	default:
@@ -718,7 +722,6 @@ func (s *Scanner) scanComment() string {
 			goto exit
 		}
 	}
-
 	s.error(offs, "comment not terminated")
 
 exit:

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -191,16 +191,6 @@ scanAgain:
 		s.next()
 		lit = s.scanText(0, false)
 		tok = token.VAR
-	case ch == '#':
-		// # can be one of three things
-		// color:    #fff[000]
-		// selector: #a
-		// interp:   #{}
-		s.next()
-		if s.ch == '{' {
-			tok, lit = s.scanInterp(offs)
-		}
-		fallthrough
 	case ch == '&':
 		fallthrough
 	case ch == ':':
@@ -237,6 +227,16 @@ exitswitch:
 	case -1:
 		tok = token.EOF
 		// Look for quoted strings
+	case '#':
+		// # can be one of three things
+		// color:    #fff[000]
+		// selector: #a
+		// interp:   #{}
+		if s.ch != '{' {
+			// send back for color or selector decision
+			goto scanAgain
+		}
+		tok, lit = s.scanInterp(offs)
 	case '\'':
 		lit = s.scanText('\'', true)
 		tok = token.QSSTRING

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -65,6 +65,7 @@ var elts = []elt{
 	{token.ATROOT, "@at-root"},
 	{token.DEBUG, "@debug"},
 	{token.ERROR, "@error"},
+	{token.VAR, "$color"},
 	// {token.COLOR, "#000"},
 	// {token.COLOR, "#abcabc"},
 	{token.MIXIN, "@mixin"},
@@ -124,9 +125,12 @@ func TestScan_selectors(t *testing.T) {
 	testScan(t, []elt{
 		{token.SELECTOR, "&.goo"},
 		{token.LBRACE, "{"},
+		{token.RULE, "color"},
+		{token.COLON, ":"},
+		{token.VALUE, "#fff"},
+		{token.SEMICOLON, ";"},
+		{token.RBRACE, "}"},
 	})
-
-	testScan(t, []elt{{token.VAR, "$color"}})
 }
 
 func TestScan_duel(t *testing.T) {
@@ -226,7 +230,8 @@ func testScan(t *testing.T, tokens []elt) {
 			}
 		}
 		if lit != elit {
-			t.Errorf("bad literal for %q: got %q, expected %q", lit, lit, elit)
+			t.Errorf("bad literal for %q: got %q, expected %q",
+				lit, lit, elit)
 		}
 
 		if tok == token.EOF {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -133,6 +133,22 @@ func TestScan_selectors(t *testing.T) {
 	})
 }
 
+func TestScan_nested(t *testing.T) {
+	testScan(t, []elt{
+		{token.SELECTOR, "&.goo"},
+		{token.LBRACE, "{"},
+		{token.SELECTOR, "div"},
+		{token.LBRACE, "{"},
+		{token.RULE, "color"},
+		{token.COLON, ":"},
+		{token.VALUE, "#fff"},
+		{token.SEMICOLON, ";"},
+		{token.RBRACE, "}"},
+		{token.RBRACE, "}"},
+	})
+
+}
+
 func TestScan_duel(t *testing.T) {
 	tokens := []byte(`$color;`)
 

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -65,11 +65,11 @@ var elts = []elt{
 	{token.ATROOT, "@at-root"},
 	{token.DEBUG, "@debug"},
 	{token.ERROR, "@error"},
-	{token.COLOR, "#000"},
-	{token.COLOR, "#abcabc"},
+	// {token.COLOR, "#000"},
+	// {token.COLOR, "#abcabc"},
 	{token.MIXIN, "@mixin"},
 	// {token.SELECTOR, "foo($a,$b)"},
-	{token.COLOR, "rgb(10,10,10)"},
+	// {token.COLOR, "rgb(10,10,10)"},
 }
 
 var source = func(tokens []elt) []byte {
@@ -116,8 +116,16 @@ func TestScan(t *testing.T) {
 
 func TestScan_selectors(t *testing.T) {
 	// selectors are so flexible, that they must be tested in isolation
-	testScan(t, []elt{{token.SELECTOR, "& > boo"}})
-	testScan(t, []elt{{token.SELECTOR, "&.goo"}})
+	testScan(t, []elt{
+		{token.SELECTOR, "& > boo"},
+		{token.LBRACE, "{"},
+	})
+
+	testScan(t, []elt{
+		{token.SELECTOR, "&.goo"},
+		{token.LBRACE, "{"},
+	})
+
 	testScan(t, []elt{{token.VAR, "$color"}})
 }
 
@@ -135,10 +143,12 @@ func TestScan_duel(t *testing.T) {
 		t.Fatalf("got: %s wanted: %s", lit, e)
 	}
 	_, tok, lit = s.Scan()
+	if e := token.SEMICOLON; e != tok {
+		t.Fatalf("got: %s wanted: %s", tok, e)
+	}
 	if e := ";"; e != lit {
 		t.Fatalf("got: %s wanted: %s", lit, e)
 	}
-	_ = tok
 }
 
 func TestScan_params(t *testing.T) {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -127,7 +127,7 @@ func TestScan_selectors(t *testing.T) {
 		{token.LBRACE, "{"},
 		{token.COMMENT, "// blah blah blah \n"},
 		{token.COMMENT, "/* hola */"},
-		{token.RULE, "color"},
+		{token.RULE, "-webkit-color"},
 		{token.COLON, ":"},
 		{token.VALUE, "#fff"},
 		{token.SEMICOLON, ";"},

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -125,6 +125,8 @@ func TestScan_selectors(t *testing.T) {
 	testScan(t, []elt{
 		{token.SELECTOR, "&.goo"},
 		{token.LBRACE, "{"},
+		{token.COMMENT, "// blah blah blah \n"},
+		{token.COMMENT, "/* hola */"},
 		{token.RULE, "color"},
 		{token.COLON, ":"},
 		{token.VALUE, "#fff"},

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -143,9 +143,7 @@ func TestScan_duel(t *testing.T) {
 
 func TestScan_params(t *testing.T) {
 	testScan(t, []elt{
-		{token.IDENT, "foo"},
 		{token.LPAREN, "("},
-		{token.IDENT, "booga-booga"},
 		{token.COMMA, ","},
 		{token.VAR, "$a"},
 		{token.VAR, "$b"},

--- a/token/token.go
+++ b/token/token.go
@@ -27,6 +27,7 @@ const (
 	QSSTRING // 'word'
 	COLOR    // #000
 	INTERP   // #{value}
+	VALUE    // value (rhs of rule)
 	literal_end
 
 	cssnums_beg
@@ -108,7 +109,6 @@ const (
 	keyword_end
 
 	CMDVAR
-	VALUE
 
 	cmd_beg
 	SPRITE


### PR DESCRIPTION
Since rules (left hand side of colon} and selectors are virtually indistinguishable, it's no longer possible to decide whether a string of characters is a rule or a selector.

Because of this, tests for individual selectors will now fail ie. `.class`, `#anchor`, `a`. Instead tests must include one of the following `;{}`. These delimiters are the only consistent characters in Sass/CSS that can be used for useful determination of what a series of characters is connected to.

- [ ] Check for and eat interpolation `#{}`