### PR TITLE
interpolation is screwing up everything

### DIFF
--- a/ast/selectors.go
+++ b/ast/selectors.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"math"
 	"regexp"
 	"strings"
 
@@ -23,317 +22,68 @@ func (stmt *SelStmt) Resolve(fset *token.FileSet) {
 	if stmt.Sel == nil {
 		panic(fmt.Errorf("invalid selector: % #v\n", stmt))
 	}
+	delim := " "
+	var par string
+	if stmt.Parent != nil {
+		par = stmt.Parent.Resolved.Value
+	}
+	val := resolve3(par, stmt.Name.Name)
 	// log.SetOutput(os.Stderr)
 	stmt.Resolved = Selector(stmt)
+	stmt.Resolved = &BasicLit{
+		Kind:     token.STRING,
+		Value:    strings.Join(val, ","+delim),
+		ValuePos: stmt.Pos(),
+	}
 	return
-	// log.SetOutput(nilW)
-	s := &sel{
-		parent: stmt.Parent,
-		stmt:   stmt,
-		prec:   token.LowestPrec + 1,
-		parts:  make(map[token.Pos]*BasicLit),
-	}
-	log.Println("Selector Resolve")
-	// Print(fset, s.stmt.Sel)
-	// This could be more efficient, it should inspect precision of
-	// the top node
-	for prec := token.UnaryPrec; prec > 1; prec-- {
-		// Walk the selectors resolving ops found at the active
-		// precision
-		if s.parent != nil {
-			s.inject = true
-		}
-		s.prec = prec
-		Walk(s, s.stmt.Sel)
-	}
-
-	// stmt.Resolved = stmt.Sel.(*BasicLit)
-	var vals []string
-	for i, part := range s.parts {
-		log.Printf("%d: % #v\n", i, part)
-		vals = append(vals, part.Value)
-	}
-	val := strings.Join(vals, " ")
-	_ = val
-	// stmt.Resolved = &BasicLit{Value: val}
-	fmt.Printf("Selector1           %q\n", strings.Split(val, ", "))
-	log.Println("Resolver Output", val)
 }
 
-type sel struct {
-	stmt   *SelStmt
-	parent *SelStmt
-	parts  map[token.Pos]*BasicLit
-	prec   int    // Resolve each precendence in order
-	stack  []Expr // Nesting stack
-	inject bool   // inject parent to start
+var r = regexp.MustCompile("\\s{2,}")
+var d = regexp.MustCompile("\\s*([+~>])\\s*")
+
+// Third time is a charm
+func resolve3(par, raw string) []string {
+	delim := " "
+	fmt.Println("raw", raw)
+	// Replace consecutive whitespace with a single whitespace
+	clean := d.ReplaceAllString(raw, " $1 ")
+	fmt.Println("1", clean)
+	//clean = d.ReplaceAllString(clean, " $1 ")
+	fmt.Println("2", clean)
+	nodes := selSplit(clean)
+	fmt.Println("clean", clean)
+	log.Printf("Resolve3 Sel        %q\n", nodes)
+	log.Printf("Parent 3            %q\n", par)
+	merged := joinParent(delim, par, nodes)
+	log.Printf("Adopted3            %q\n", merged)
+	return merged
 }
 
-func (s *sel) add(pos token.Pos, lit *BasicLit) {
-	s.parts[pos] = lit
-	// FIXME: walk through all available positions and remove
-	// any higher than pos. This indicates a reduce happened
-	// and something was reported prematurely
-	for i := range s.parts {
-		if i > pos {
-			delete(s.parts, i)
+func selSplit(s string) []string {
+	ss := strings.Split(s, ",")
+	for i := range ss {
+		ss[i] = strings.TrimSpace(ss[i])
+		if !strings.Contains(ss[i], "&") {
+			// Add implicit ampersand
+			ss[i] = "& " + ss[i]
 		}
 	}
+	return ss
 }
 
-var amper = "&"
-
-func ghettoResolvedParentInject(delim string, pval string, nodes ...string) string {
-	log.Printf(`=ghetto=============================
-     op: %q
- parent: %q
- childs: %q
-====================================
-`,
-		delim, pval, nodes,
-	)
-	gdelim := ", "
-
-	if len(pval) == 0 {
-		return strings.Join(nodes, gdelim)
+func joinParent(delim, parent string, nodes []string) []string {
+	rep := "&"
+	if len(parent) == 0 {
+		rep = "& "
 	}
-
-	sdelim := ", "
-	parts := strings.Split(pval, sdelim)
-	ret := make([]string, 0, len(parts)*len(nodes))
-	var s string
+	commadelim := "," + delim
+	parts := strings.Split(parent, commadelim)
+	var ret []string
 	for i := range parts {
 		for j := range nodes {
-			// When no & is present, & is implicit ie. `& parts[i]`
-			if strings.Contains(nodes[j], amper) {
-				s = strings.Replace(nodes[j], "&", parts[i], -1)
-			} else {
-				s = parts[i] + delim + nodes[j]
-			}
-			ret = append(ret, s)
+			rep := strings.Replace(nodes[j], rep, parts[i], -1)
+			ret = append(ret, rep)
 		}
 	}
-	log.Printf(`=ghetto return======================
- %q
-====================================
-`, ret)
-	return strings.Join(ret, gdelim)
-}
-
-// FIXME: have no way to merge trees right now, so ghetto style
-func ghettoParentInject(delim string, parent *SelStmt, nodes ...string) string {
-	var pval string
-	if parent != nil {
-		pval = parent.Resolved.Value
-	}
-	return ghettoResolvedParentInject(delim, pval, nodes...)
-}
-
-func (s *sel) Visit(node Node) Visitor {
-	// log.Printf("Visit %T: % #v\n", node, node)
-	var pos token.Pos
-	var add *BasicLit
-	delim := " "
-	defer func() {
-		if add == nil {
-			return
-		}
-		if add.Kind == token.ILLEGAL {
-			log.Println("Warning invalid Kind for", add)
-		}
-		// Do not add Lits with invalid positions
-		if pos >= 0 {
-			s.add(pos, add)
-			log.Printf("adding %s at %d: % #v\n", add.Kind, pos, add)
-		}
-	}()
-
-	switch v := node.(type) {
-	case *UnaryExpr:
-		// UnaryExpr come in two flavors & (backref) and + ~ > (operators).
-		// In any case, it must be nested selector or it is an error.
-		if s.parent == nil {
-			// TODO: pass through parser's exception logic
-			log.Fatal("unary operator must be a nested selector",
-				node.Pos())
-		}
-		if v.Visited {
-			return nil
-		}
-		if s.prec < 5 {
-			panic(fmt.Errorf("invalid nest token: %s prec: %d", v.Op, s.prec))
-		}
-		if s.prec != 5 {
-			return nil
-		}
-
-		v.Visited = true
-
-		pos = v.OpPos
-		switch v.Op {
-		case token.NEST, token.GTR, token.TIL, token.ADD:
-			log.Println("unary binary add!")
-			add = s.switchExpr(v)
-		default:
-			log.Fatal("invalid unary operation: ", v.Op)
-		}
-		return nil
-	case *BasicLit:
-		if v.Kind == token.ILLEGAL {
-			return nil
-		}
-		if s.prec != 2 {
-			return nil
-		}
-
-		if s.inject && s.parent != nil {
-			v.Value = ghettoParentInject(delim, s.parent, v.Value)
-		}
-		add = v
-		return nil
-	case *BinaryExpr:
-		pos = v.Pos()
-		switch v.Op {
-		case token.ADD, token.GTR, token.TIL:
-			if s.prec < 4 {
-				return nil
-				panic(fmt.Errorf("invalid Op token: %s prec: %d", v.Op, s.prec))
-			}
-			if s.prec != 4 {
-				return s
-			}
-			add = s.switchExpr(v)
-		case token.COMMA:
-			if s.prec < 3 {
-				return nil
-				panic(fmt.Errorf("invalid group token: %s prec: %d", v.Op, s.prec))
-			}
-			if s.prec != 3 {
-				return nil
-			}
-
-			// Group (,) can be treated as two separate expressions
-			litX := s.switchExpr(v.X)
-			litY := s.switchExpr(v.Y)
-			sx := mergeLits(","+delim, litX.Value, litY.Value)
-			add = &BasicLit{
-				Kind:     token.STRING,
-				ValuePos: pos,
-				Value:    sx,
-			}
-		}
-		return nil
-	}
-
-	return s
-}
-
-// after parent multiplication, lits are out of order. Fix the ordering
-// Examples of out of orderness
-// [1 3] [2] => [1 2 3]
-// [1 3] [2 4] => [1 2 3 4]
-func mergeLits(delim, left, right string) string {
-	lefts, rights := strings.Split(left, delim), strings.Split(right, delim)
-	ll, lr := len(lefts), len(rights)
-	log.Printf("reordering %d %d\nleft: %q\nrigh: %q\n",
-		ll, lr, lefts, rights)
-
-	if math.Remainder(float64(ll), float64(lr)) > 0 {
-		panic(fmt.Errorf("Incompatible lengths left:%d right:%d", ll, lr))
-	}
-	var ss []string
-	mod := ll / lr
-	for i := range lefts {
-		ss = append(ss, lefts[i])
-		if (i+1)%mod == 0 {
-			ss = append(ss, rights[i/mod])
-		}
-	}
-	log.Printf("%q\n", ss)
-	r := strings.Join(ss, delim)
-	log.Println("mergeLits returns", r)
-	return r
-}
-
-func parseBackRef(delim string, parent *BasicLit, in *BasicLit) *BasicLit {
-	log.Printf("parseBackRef % #v\n", in)
-	if in.Value == "&" {
-		return ExprCopy(parent).(*BasicLit)
-	}
-	pval := parent.Value
-	ret := ghettoResolvedParentInject(delim, pval, in.Value)
-	return &BasicLit{
-		Kind:     token.STRING,
-		Value:    ret,
-		ValuePos: in.Pos(),
-	}
-}
-
-func (s *sel) switchExpr(expr Expr) *BasicLit {
-	log.Printf("switchExpr %T: % #v\n", expr, expr)
-	delim := " "
-	switch v := expr.(type) {
-	case *BasicLit:
-		copy := ExprCopy(expr).(*BasicLit)
-		copy.ValuePos = v.ValuePos
-		copy.Value = ghettoParentInject(" ", s.parent, v.Value)
-		return copy
-	case *UnaryExpr:
-		plit := parseBackRef(delim+v.Op.String()+delim, s.parent.Resolved, v.X.(*BasicLit))
-		log.Printf("switchExpr exit % #v\n", plit)
-		return plit
-	case *BinaryExpr:
-		log.Printf("switching bin\n  X:% #v\n  Y:% #v\n", v.X, v.Y)
-		return s.joinBinary(v)
-	default:
-		panic(fmt.Errorf("switch expr: % #v\n", v))
-	}
-}
-
-func (s *sel) joinBinary(bin *BinaryExpr) *BasicLit {
-	log.Println("joinBinary")
-	delim := " " // This will change with compiler mode
-	switch bin.Op {
-	case token.COMMA:
-		delim = "," + delim
-	default:
-		delim = delim + bin.Op.String() + delim
-	}
-
-	_, unx := bin.X.(*UnaryExpr)
-	_, uny := bin.Y.(*UnaryExpr)
-
-	x := s.switchExpr(bin.X)
-	y := s.switchExpr(bin.Y)
-	log.Printf("joining with (%q)\n  X: % #v\n  Y: % #v\n", delim, x, y)
-	var val string
-	if unx && uny {
-		// If both are Unary, must use ghetto math to multiply them
-		log.Println("join unx&uny\nleft:", x.Value, "\nright:", y.Value)
-		val = ghettoResolvedParentInject(delim, x.Value, y.Value)
-	} else if unx {
-		log.Println("join unx")
-		// This is actually a unary operation, treat as so
-		un := &UnaryExpr{
-			Op:    bin.Op,
-			OpPos: bin.OpPos,
-			X:     bin.Y,
-		}
-		log.Printf("unary switch (%q): % #v", bin.Op, bin.Y)
-		return s.switchExpr(un)
-	} else if bin.Op == token.COMMA {
-		val = mergeLits(delim, x.Value, y.Value)
-	} else {
-		log.Println("join other")
-		vals := []string{x.Value, y.Value}
-		val = strings.Join(vals, delim)
-	}
-
-	lit := &BasicLit{
-		ValuePos: bin.Pos(),
-		Value:    val,
-		Kind:     token.STRING,
-	}
-	log.Printf("binJoined: %s\n", val)
-	return lit
+	return ret
 }

--- a/ast/selectors.go
+++ b/ast/selectors.go
@@ -3,7 +3,6 @@ package ast
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 
@@ -22,41 +21,9 @@ func (stmt *SelStmt) Resolve(fset *token.FileSet) {
 	if stmt.Sel == nil {
 		panic(fmt.Errorf("invalid selector: % #v\n", stmt))
 	}
-	delim := " "
-	var par string
-	if stmt.Parent != nil {
-		par = stmt.Parent.Resolved.Value
-	}
-	val := resolve3(par, stmt.Name.Name)
-	// log.SetOutput(os.Stderr)
+
 	stmt.Resolved = Selector(stmt)
-	stmt.Resolved = &BasicLit{
-		Kind:     token.STRING,
-		Value:    strings.Join(val, ","+delim),
-		ValuePos: stmt.Pos(),
-	}
 	return
-}
-
-var r = regexp.MustCompile("\\s{2,}")
-var d = regexp.MustCompile("\\s*([+~>])\\s*")
-
-// Third time is a charm
-func resolve3(par, raw string) []string {
-	delim := " "
-	fmt.Println("raw", raw)
-	// Replace consecutive whitespace with a single whitespace
-	clean := d.ReplaceAllString(raw, " $1 ")
-	fmt.Println("1", clean)
-	//clean = d.ReplaceAllString(clean, " $1 ")
-	fmt.Println("2", clean)
-	nodes := selSplit(clean)
-	fmt.Println("clean", clean)
-	log.Printf("Resolve3 Sel        %q\n", nodes)
-	log.Printf("Parent 3            %q\n", par)
-	merged := joinParent(delim, par, nodes)
-	log.Printf("Adopted3            %q\n", merged)
-	return merged
 }
 
 func selSplit(s string) []string {

--- a/ast/selectors2.go
+++ b/ast/selectors2.go
@@ -1,14 +1,13 @@
 package ast
 
 import (
-	"log"
 	"strings"
 
 	"github.com/wellington/sass/token"
 )
 
 func Selector(stmt *SelStmt) *BasicLit {
-	log.Printf("\n==Selector=====\n")
+	// log.Printf("\n==Selector=====\n")
 	// Merge the selector to groups
 	delim := " "
 	merged := mergeExpr(delim, stmt.Sel, 0)
@@ -16,10 +15,10 @@ func Selector(stmt *SelStmt) *BasicLit {
 	if stmt.Parent != nil {
 		par = stmt.Parent.Resolved.Value
 	}
-	log.Printf("Sel                 %q\n", stmt.Name)
-	log.Printf("Merged              %q\n", merged)
+	// log.Printf("Sel                 %q\n", stmt.Name)
+	// log.Printf("Merged              %q\n", merged)
 	merged = joinParent(delim, par, merged)
-	log.Printf("Adopted             %q\n", merged)
+	// log.Printf("Adopted             %q\n", merged)
 	return &BasicLit{
 		Value:    strings.Join(merged, ","+delim),
 		ValuePos: stmt.Pos(),

--- a/ast/selectors2.go
+++ b/ast/selectors2.go
@@ -1,13 +1,14 @@
 package ast
 
 import (
+	"log"
 	"strings"
 
 	"github.com/wellington/sass/token"
 )
 
 func Selector(stmt *SelStmt) *BasicLit {
-	// log.Printf("\n==Selector=====\n")
+	log.Printf("\n==Selector=====\n")
 	// Merge the selector to groups
 	delim := " "
 	merged := mergeExpr(delim, stmt.Sel, 0)
@@ -15,10 +16,10 @@ func Selector(stmt *SelStmt) *BasicLit {
 	if stmt.Parent != nil {
 		par = stmt.Parent.Resolved.Value
 	}
-	// log.Printf("Sel                 %q\n", stmt.Name)
-	// log.Printf("Merged              %q\n", merged)
+	log.Printf("Sel                 %q\n", stmt.Name)
+	log.Printf("Merged              %q\n", merged)
 	merged = joinParent(delim, par, merged)
-	// log.Printf("Adopted             %q\n", merged)
+	log.Printf("Adopted             %q\n", merged)
 	return &BasicLit{
 		Value:    strings.Join(merged, ","+delim),
 		ValuePos: stmt.Pos(),
@@ -26,25 +27,8 @@ func Selector(stmt *SelStmt) *BasicLit {
 	}
 }
 
-func joinParent(delim, parent string, nodes []string) []string {
-	rep := "&"
-	if len(parent) == 0 {
-		rep = "& "
-	}
-	commadelim := "," + delim
-	parts := strings.Split(parent, commadelim)
-	var ret []string
-	for i := range parts {
-		for j := range nodes {
-			rep := strings.Replace(nodes[j], rep, parts[i], -1)
-			ret = append(ret, rep)
-		}
-	}
-	return ret
-}
-
 // mergeExpr recursively merges expressions into slice of groups
-// a + b, ~ d => [a + b, ~ d]
+// a + b, ~ d => ['a + b', '~ d']
 func mergeExpr(delim string, expr Expr, round int) []string {
 	// fmt.Printf("round %d: %-15T %v\n", round, expr, expr)
 	var ret []string

--- a/calc/math.go
+++ b/calc/math.go
@@ -2,7 +2,6 @@ package calc
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -45,8 +44,8 @@ func resolve(in ast.Expr) (*ast.BasicLit, error) {
 		// TODO: commas are missing
 		x.Value = strings.Join(val, ", ")
 	default:
-		log.Fatalf("% #v\n", v)
 		err = fmt.Errorf("unsupported calc.resolve % #v\n", v)
+		panic(err)
 	}
 	return x, err
 }

--- a/compiler/compile_test.go
+++ b/compiler/compile_test.go
@@ -173,6 +173,41 @@ func TestSelector_deep_nesting(t *testing.T) {
 	}
 }
 
+func TestSelector_selector_interp(t *testing.T) {
+	ctx := &Context{}
+	ctx.Init()
+	ctx.fset = token.NewFileSet()
+	input := `$x: oo, ba;
+$y: az, hu;
+
+f#{$x}r {
+  p: 1;
+  b#{$y}x {
+    q: 2;
+    mumble#{length($x) + length($y)} {
+      r: 3;
+    }
+  }
+}
+`
+	out, err := ctx.run("", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := `foo, bar {
+  p: 1; }
+  foo baz, foo hux, bar baz, bar hux {
+    q: 2; }
+    foo baz mumble4, foo hux mumble4, bar baz mumble4, bar hux mumble4 {
+      r: 3; }
+`
+	if e != out {
+		t.Fatalf("got:\n%s\nwanted:\n%s", out, e)
+	}
+
+}
+
 func TestSelector_nesting_implicit_unary(t *testing.T) {
 
 	ctx := &Context{}

--- a/compiler/compile_test.go
+++ b/compiler/compile_test.go
@@ -27,8 +27,8 @@ func findPaths() []file {
 	var files []file
 	// files := make([]file, len(inputs))
 	for _, input = range inputs {
-		if !strings.Contains(input, "07_") {
-			// continue
+		if !strings.Contains(input, "26_") {
+			continue
 		}
 		// detailed commenting
 		if strings.Contains(input, "06_") {

--- a/compiler/compile_test.go
+++ b/compiler/compile_test.go
@@ -27,8 +27,8 @@ func findPaths() []file {
 	var files []file
 	// files := make([]file, len(inputs))
 	for _, input = range inputs {
-		if !strings.Contains(input, "26_") {
-			//continue
+		if !strings.Contains(input, "07_") {
+			// continue
 		}
 		// detailed commenting
 		if strings.Contains(input, "06_") {
@@ -81,6 +81,7 @@ compiling: %s\n
 =================================
 `, f.input)
 		ctx := Context{mode: parser.Trace}
+		ctx.mode = 0
 		ctx.Init()
 		out, err := ctx.Run(f.input)
 		sout := strings.Replace(out, "`", "", -1)

--- a/compiler/compile_test.go
+++ b/compiler/compile_test.go
@@ -28,7 +28,7 @@ func findPaths() []file {
 	// files := make([]file, len(inputs))
 	for _, input = range inputs {
 		if !strings.Contains(input, "26_") {
-			continue
+			// continue
 		}
 		// detailed commenting
 		if strings.Contains(input, "06_") {

--- a/parser/interpolate.go
+++ b/parser/interpolate.go
@@ -4,16 +4,20 @@ import "github.com/wellington/sass/ast"
 
 // mergeExprs looks for interpolation and performs literal merges
 // The return is just a string, so YMMV
-func itpMerge(in []ast.Expr) string {
+func itpMerge(in []ast.Expr) (string, bool) {
+	var found bool
 	var comb string
 	for i := range in {
+		if _, ok := in[i].(*ast.Interp); ok {
+			found = true
+		}
 		if i+1 >= len(in) {
 			continue
 		}
 		comb += itpExpand(in[i], in[i+1])
 	}
 	comb += itpExpand(in[len(in)-1], nil)
-	return comb
+	return comb, found
 }
 
 func itpExpand(left, right ast.Expr) string {

--- a/parser/interpolate.go
+++ b/parser/interpolate.go
@@ -1,0 +1,33 @@
+package parser
+
+import "github.com/wellington/sass/ast"
+
+// mergeExprs looks for interpolation and performs literal merges
+// The return is just a string, so YMMV
+func itpMerge(in []ast.Expr) string {
+	var comb string
+	for i := range in {
+		if i+1 >= len(in) {
+			continue
+		}
+		comb += itpExpand(in[i], in[i+1])
+	}
+	comb += itpExpand(in[len(in)-1], nil)
+	return comb
+}
+
+func itpExpand(left, right ast.Expr) string {
+	var s string
+	switch v := left.(type) {
+	case *ast.Interp:
+		s += v.Obj.Decl.(*ast.BasicLit).Value
+	case *ast.BasicLit:
+		s += v.Value
+	}
+	if right != nil {
+		if left.End() < right.Pos() {
+			s += " "
+		}
+	}
+	return s
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2843,12 +2843,16 @@ func (p *parser) parseSelStmt(backrefOk bool) *ast.SelStmt {
 	var xs []ast.Expr
 	for p.tok != token.LBRACE {
 		x := p.parseCombSel(token.LowestPrec + 1)
-		if xx, ok := x.(*ast.Interp); ok {
-			lit := xx.Obj.Decl.(*ast.BasicLit)
-			fmt.Printf("%s:%s\n", lit.Kind, lit.Value)
-		}
+		// if xx, ok := x.(*ast.Interp); ok {
+		// lit := xx.Obj.Decl.(*ast.BasicLit)
+		// fmt.Printf("%s:%s\n", lit.Kind, lit.Value)
+		// }
 		xs = append(xs, x)
 	}
+
+	s := itpMerge(xs)
+	fmt.Printf("xs:% #v\n", xs)
+	fmt.Println("itpMerge", s)
 
 	sel.Sel = xs[0]
 	sel.Resolve(Globalfset)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -224,7 +224,7 @@ func (s *Scanner) skipWhitespace() {
 // New strategy, scan until something important is encountered
 func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
 	defer func() {
-		fmt.Printf("scan tok: %s lit: %q pos: %d\n", tok, lit, pos)
+		// fmt.Printf("scan tok: %s lit: %q pos: %d\n", tok, lit, pos)
 	}()
 
 	// Check the queue, which may contain tokens that were fetched


### PR DESCRIPTION
`next()` should lookahead, and resolve interpolations rather than returning them. By doing this, the various parsers and would not need to care about interpolations. The joining of interpolation to outside tokens always follows simple string operations as shown below.

`prop: 1{3+4};` -> `prop: 17`
`div#{#id}` -> `div#id`

Interpolation expansion can not happen during scanning, since the scanner lacks the syntax awareness to perform complex tasks like
`#{length(asdf)}` -> `4`